### PR TITLE
Feature: Dynamic Serverleaks checks

### DIFF
--- a/privacyscore/test_suites/serverleak.py
+++ b/privacyscore/test_suites/serverleak.py
@@ -124,7 +124,7 @@ def _get(url, timeout):
         return None
 
 def test_site(url: str, previous_results: dict) -> Dict[str, Dict[str, Union[str, bytes]]]:
-    raw_requests = {}
+    raw_requests = {"url": url}
 
     # determine hostname
     parsed_url = urlparse(url)
@@ -138,7 +138,6 @@ def test_site(url: str, previous_results: dict) -> Dict[str, Dict[str, Union[str
                 trial_t = trial(url)
                 if trial_t is None:
                     continue
-                print(trial_t)
             request_url = '{}://{}/{}'.format(
                 parsed_url.scheme, parsed_url.netloc, trial_t)
             url_to_future[trial_t] = executor.submit(_get, request_url, 10)
@@ -170,7 +169,15 @@ def process_test_data(raw_data: list, previous_results: dict) -> Dict[str, Dict[
     leaks = []
     result = {}
     
+    url = raw_data.get("url", None)
+
     for trial, pattern in TRIALS:
+        if url:
+            if callable(trial):
+                trial = trial(url)
+                if trial is None:
+                    continue
+                print(trial)
         if trial not in raw_data:
             # Test raw data too old or particular request failed.
             continue

--- a/privacyscore/test_suites/serverleak.py
+++ b/privacyscore/test_suites/serverleak.py
@@ -177,7 +177,6 @@ def process_test_data(raw_data: list, previous_results: dict) -> Dict[str, Dict[
                 trial = trial(url)
                 if trial is None:
                     continue
-                print(trial)
         if trial not in raw_data:
             # Test raw data too old or particular request failed.
             continue

--- a/privacyscore/test_suites/serverleak.py
+++ b/privacyscore/test_suites/serverleak.py
@@ -185,11 +185,11 @@ def process_test_data(raw_data: list, previous_results: dict) -> Dict[str, Dict[
         if response['status_code'] == 200:
             # The pattern can have three different types.
             # - If it is a simple string, we only check if it is contained in the response
-            if type(pattern) is str:
+            if isinstance(pattern, str):
                 if pattern in response['text']:
                     leaks.append(trial)
             # - If it is a RegEx object, we perform a pattern match
-            elif type(pattern) is re._pattern_type:
+            elif isinstance(pattern, re._pattern_type):
                 if re.match(response['text']):
                     leaks.append(trial)
             # - If it is callable, we call it with the response text and check the return value


### PR DESCRIPTION
The serverleaks checks are currently static (i.e. hardcoded filename, hardcoded string to check for). This makes them hard to adapt (i.e., when checking domain.tld, we may want to look for domain.sql as a filename for an SQL dump).

This PR adds the following new features:
- **Filenames can be given as callables**, in which case the callable will be called with the URL of the tested site as parameter. It should return a string (filename to check for) or None (in which case the trial will be skipped)
- The evaluation of results can now happen in three different ways:
  - **String match**: See if string is contained in results, as before
  - **Regular expression**: See if a regular expression is matched
  - **Callable**: A callable is called with the retrieved data as parameter and returns True or False.