### PR TITLE
Add basic website blacklist functionality

### DIFF
--- a/privacyscore/backend/admin.py
+++ b/privacyscore/backend/admin.py
@@ -1,13 +1,16 @@
 from django.contrib import admin
 
 
-from privacyscore.backend.models import ScanList, Site, ListTag, ListColumn, \
-    ListColumnValue, Scan, RawScanResult, ScanResult, ScanError
+from privacyscore.backend.models import BlacklistEntry, ScanList, Site, \
+    ListTag, ListColumn, ListColumnValue, Scan, RawScanResult, ScanResult, \
+    ScanError
 
 
 admin.site.register(ListColumn)
 admin.site.register(ListColumnValue)
 admin.site.register(ListTag)
+
+admin.site.register(BlacklistEntry)
 
 @admin.register(RawScanResult)
 class RawScanResultAdmin(admin.ModelAdmin):


### PR DESCRIPTION
This PR adds the possibility for basic blacklisting of domains or subdomains.

TODOs (not necessarily for this PR):
- [x] Blacklisting based on Domain or Subdomain
- [x] Prevent rescans of blacklisted domains
- [ ] Improve transparency 
  - [ ] notify users if they try to scan a blacklisted domain
  - [ ] Add a list of all blacklisted domains to the website, including reason
- [ ] Actually test this PR (I don't have a test setup)