### PR TITLE
Blacklist transparency

### DIFF
--- a/privacyscore/backend/management/commands/scanfromfile.py
+++ b/privacyscore/backend/management/commands/scanfromfile.py
@@ -46,9 +46,14 @@ class Command(BaseCommand):
             }
         scan_count = 0
         for site in sites:
-            if not site.scan():
+            status_code = site.scan()
+            if status_code == Site.SCAN_COOLDOWN:
                 self.stdout.write(
                     'Rate limiting -- Not scanning site {}'.format(site))
+                continue
+            if status_code == Site.SCAN_BLACKLISTED:
+                self.stdout.write(
+                    'Blacklisted -- Not scanning site {}'.format(site))
                 continue
             scan_count += 1
             self.stdout.write('Scanning site {}'.format(

--- a/privacyscore/backend/management/commands/schedulerescans.py
+++ b/privacyscore/backend/management/commands/schedulerescans.py
@@ -55,12 +55,13 @@ class Command(BaseCommand):
             for i in range(min(MAX_TRIES, len(sites))):
                 site = sites.pop()
                 
-                if site.scan():
+                status_code = site.scan()
+                if status_code == Site.SCAN_OK:
                     self.stdout.write('Scheduled scan of {}'.format(str(site)))
                     self.stdout.flush()
                     break
                 else:
-                    self.stdout.write('Not scheduling scan of {} -- too recent or running'.format(str(site)))
+                    self.stdout.write('Not scheduling scan of {} -- Reason: {}'.format(str(site), str(status_code)))
                     self.stdout.flush()
                     sleep(0.5)
             

--- a/privacyscore/backend/models.py
+++ b/privacyscore/backend/models.py
@@ -159,7 +159,7 @@ class ScanList(models.Model):
 
         res = False
         for site in self.sites.all():
-            if site.scan() == Site.SCAN_SCHEDULED:
+            if site.scan() == Site.SCAN_OK:
                 res = True
         
         if self.editable:
@@ -331,7 +331,7 @@ class Site(models.Model):
         """
         Schedule a scan of this site if requirements are fulfilled.
 
-        Returns a status code from the list SCAN_SCHEDULED, SCAN_COOLDOWN,
+        Returns a status code from the list SCAN_OK, SCAN_COOLDOWN,
         SCAN_BLACKLISTED.
         """
 

--- a/privacyscore/frontend/templates/frontend/view_site.html
+++ b/privacyscore/frontend/templates/frontend/view_site.html
@@ -182,6 +182,9 @@ table.dataTable thead .sorting_desc_disabled
 <div class="row">
     <div class="col-sm-8">
         <div class="row">
+            { % if site.scannable == site.SCAN_BLACKLISTED % }
+                <div class="alert alert-danger">This website has requested not to be scanned anymore. No more scans are possible.</div>
+            {% endif % }
             <div class="col-sm-6">
                 <p><small>ANALYZED URL AFTER LOADING:</small><br>
                     <span style="word-wrap: break-word;">

--- a/privacyscore/frontend/templates/frontend/view_site.html
+++ b/privacyscore/frontend/templates/frontend/view_site.html
@@ -182,9 +182,14 @@ table.dataTable thead .sorting_desc_disabled
 <div class="row">
     <div class="col-sm-8">
         <div class="row">
-            { % if site.scannable == site.SCAN_BLACKLISTED % }
-                <div class="alert alert-danger">This website has requested not to be scanned anymore. No more scans are possible.</div>
-            {% endif % }
+            {% if site.scannable == site.SCAN_BLACKLISTED %}
+	    <div class="alert alert-danger"><b>This site has been blacklisted.</b>
+		The owner of this website has asked us to not perform further scans.
+		For reasons of transparency we display
+	       	the results of the last scan before the site was blacklisted. The owner may have
+		implemented changes in the meantime, which are not visible in the results below.
+		</div>
+            {% endif %}
             <div class="col-sm-6">
                 <p><small>ANALYZED URL AFTER LOADING:</small><br>
                     <span style="word-wrap: break-word;">

--- a/privacyscore/frontend/templates/frontend/view_site.html
+++ b/privacyscore/frontend/templates/frontend/view_site.html
@@ -131,17 +131,17 @@ table.dataTable thead .sorting_desc_disabled
     </div>
     <div class="col-sm-4">
         
-        {% if site.scannable %}
+        {% if site.scannable == site.SCAN_OK %}
         <form method="POST" action="{% url 'frontend:scan_site' site.pk %}">
             {% csrf_token %}
         {% endif %}
             <button type="submit" class="btn btn-default btn-primary btn-lg" role="button" id="scan_again" style="width:100%; margin-top:5px; margin-bottom:10px"
-            {% if not site.scannable %}
+            {% if not site.scannable == site.SCAN_OK %}
                 disabled
             {% endif %}>
                 {% trans 'Re-scan site now' %}
             </button>
-        {% if site.scannable %}
+        {% if site.scannable == site.SCAN_OK %}
         </form>
         {% endif %}
     
@@ -154,8 +154,10 @@ table.dataTable thead .sorting_desc_disabled
                 </a>
             </div>
         {% else %}
-            {% if site.scannable %}
+            {% if site.scannable == site.SCAN_OK %}
                 <h3 class="text-center color-primary"><smalL>AVAILABLE FOR RE-SCAN</small></h3>
+            {% elif site.scannable == site.SCAN_BLACKLISTED %}
+                <h3 class="text-center color-red"><smalL>WEBSITE IS BLACKLISTED</small></h3>
             {% else %}
                 <h3 class="text-center color-neutral"><smalL>RE-SCAN NOT AVAILABLE YET</small></h3>
             {% endif %}


### PR DESCRIPTION
This PR continues the work of #14 by providing more transparency about the blacklist. If someone tries to scan a website that is blacklisted, this fact will be communicated more clearly.

TODO:
- [x] Highlight blocked status on detailed scan view
- [ ] Highlight blacklisted websites in ranking
- [ ] Provide list of all blacklisted websites including reason in a public place
- [ ] Test everything