### PR TITLE
Frontend: Comment out serverleaks in FAQ for performance reasons

### DIFF
--- a/privacyscore/frontend/templates/frontend/faq.html
+++ b/privacyscore/frontend/templates/frontend/faq.html
@@ -66,10 +66,10 @@
         <p>
           <b>A:</b> {{ num_scans }}<br />
         </p>
-        <p>
+        <!-- <p>
           <b>Q:</b> How many sites have you seen that seem to disclose internal system information unintentionally?<br />
           <b>A:</b> {{ num_sites_failing_serverleak }}<br />
-        </p>
+        </p> -->
     </div>
 </div>
 

--- a/privacyscore/frontend/views.py
+++ b/privacyscore/frontend/views.py
@@ -626,24 +626,24 @@ def faq(request: HttpRequest):
     num_scans  = Site.objects.filter(scans__isnull=False).count()
     num_scanning_sites = Scan.objects.filter(end__isnull=True).count()
 
-    query = '''SELECT
-        COUNT(jsonb_array_length("result"->'leaks'))
-        FROM backend_scanresult
-        WHERE backend_scanresult.scan_id IN (
-            SELECT backend_site.last_scan_id
-            FROM backend_site
-            WHERE backend_site.last_scan_id IS NOT NULL)
-        AND jsonb_array_length("result"->'leaks') > 0'''
-    
-    with connection.cursor() as cursor:
-        cursor.execute(query)
-        num_sites_failing_serverleak = cursor.fetchone()[0]
+    # query = '''SELECT
+    #     COUNT(jsonb_array_length("result"->'leaks'))
+    #     FROM backend_scanresult
+    #     WHERE backend_scanresult.scan_id IN (
+    #         SELECT backend_site.last_scan_id
+    #         FROM backend_site
+    #         WHERE backend_site.last_scan_id IS NOT NULL)
+    #     AND jsonb_array_length("result"->'leaks') > 0'''
+    # 
+    # with connection.cursor() as cursor:
+    #     cursor.execute(query)
+    #     num_sites_failing_serverleak = cursor.fetchone()[0]
         
     return render(request, 'frontend/faq.html', {
         'num_scanning_sites': num_scanning_sites,
         'num_scans':  num_scans,
         'num_sites': Site.objects.count(),
-        'num_sites_failing_serverleak': num_sites_failing_serverleak
+        # 'num_sites_failing_serverleak': num_sites_failing_serverleak
     })
 
 


### PR DESCRIPTION
Given the increasingly large database, the serverleaks stats for the frontend take forever to generate (15+ seconds). To reduce page load times for the FAQ, I commented the stats out for now, until we can write better code for this that uses caching or something.