### PR TITLE
Fix path ImportError related to Django version

### DIFF
--- a/privacyscore/urls.py
+++ b/privacyscore/urls.py
@@ -17,12 +17,11 @@ import sys
 from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib import admin
-from django.urls import path
 
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    path(r'i18n/', include('django.conf.urls.i18n')),
+    url(r'i18n/', include('django.conf.urls.i18n')),
     #url(r'^api/', include('privacyscore.api.urls')),
     url(r'^', include('privacyscore.frontend.urls')),
 ]


### PR DESCRIPTION
requirements.txt specifies `Django<1.12`. `urls.py` attempts to
import `path` from `django.urls`, which is not available in
`Django<1.12`. With this patch, we use `url` imported from
`django.conf.urls` instead of `path`.