### PR TITLE
Add caching to view_scan_list and view_site

### DIFF
--- a/privacyscore/flexcache/__init__.py
+++ b/privacyscore/flexcache/__init__.py
@@ -21,7 +21,7 @@ MIDDLEWARE_TOKEN_REGEXP = re.compile(b"name='csrfmiddlewaretoken' value='([a-zA-
 
 
 def flexcache_view(view_fn, cache_prefix, placeholders=None, include_path=True,
-                   include_querystring=True):
+                   include_querystring=True, **cache_options):
     if placeholders is None:
         placeholders = {}
 
@@ -44,7 +44,7 @@ def flexcache_view(view_fn, cache_prefix, placeholders=None, include_path=True,
             content = response.content
             content_type = response.get('Content-Type', 'text/html')
             fragments = build_content_fragments(content, request, template_context)
-            cache.set(cache_key, (content_type, fragments))
+            cache.set(cache_key, (content_type, fragments), **cache_options)
             return response
         else:
             content_type, fragments = cache_data

--- a/privacyscore/flexcache/__init__.py
+++ b/privacyscore/flexcache/__init__.py
@@ -1,0 +1,125 @@
+import base64
+import enum
+import functools
+import hashlib
+import os
+import re
+
+from django.core.cache import cache
+from django.http import HttpResponse
+from django.middleware.csrf import get_token
+from django.template.response import TemplateResponse
+
+
+class FragmentType(enum.IntEnum):
+    CONTENT = 1
+    CSRFTOKEN = 2
+    PLACEHOLDER = 3
+
+
+MIDDLEWARE_TOKEN_REGEXP = re.compile(b"name='csrfmiddlewaretoken' value='([a-zA-Z0-9]+)'")
+
+
+def flexcache_view(view_fn, cache_prefix, placeholders=None, include_path=True,
+                   include_querystring=True):
+    if placeholders is None:
+        placeholders = {}
+
+    @functools.wraps(view_fn)
+    def _cached_view(request, *args, **kwargs):
+        path = request.path_info if include_path else ''
+        query_string = request.META['QUERY_STRING'] if include_querystring else ''
+        cache_hash = hashlib.sha256('{}?{}'.format(path, query_string).encode()).hexdigest()
+        cache_key = '{}:{}'.format(cache_prefix, cache_hash)
+
+        cache_data = cache.get(cache_key)
+        if cache_data is None:
+            response = view_fn(request, *args, **kwargs)
+            if response.status_code != 200:
+                return response
+            template_context = None
+            if isinstance(response, TemplateResponse):
+                template_context = response.context_data
+                response.render()
+            content = response.content
+            content_type = response.get('Content-Type', 'text/html')
+            fragments = build_content_fragments(content, request, template_context)
+            cache.set(cache_key, (content_type, fragments))
+            return response
+        else:
+            content_type, fragments = cache_data
+            content = render_content_fragments(fragments, placeholders, request)
+            return HttpResponse(content, content_type=content_type)
+
+    return _cached_view
+
+
+def build_content_fragments(content, request, template_context=None):
+    # Prepare regular expression to split the content into fragments
+    csrf_token = template_context.get('csrf_token') if template_context else None
+    if csrf_token is None:
+        csrf_match = MIDDLEWARE_TOKEN_REGEXP.search(content)
+        if csrf_match:
+            csrf_token = csrf_match.group(1).decode()
+    placeholders = getattr(request, 'flexcache_placeholders', {})
+    regexp = None
+    if placeholders:
+        regexp = '|'.join(re.escape(needle) for needle in placeholders.keys())
+        if csrf_token:
+            regexp += '|' + re.escape(csrf_token)
+    else:
+        if csrf_token:
+            regexp = re.escape(csrf_token)
+
+    # We have nothing to replace in the content
+    if regexp is None:
+        return [(FragmentType.CONTENT, content)]
+
+    regexp = re.compile(regexp.encode())
+
+    fragments = []
+    pos = 0
+    end = 0
+    for match in regexp.finditer(content):
+        start = match.start(0)
+        end = match.end(0)
+        content_fragment = content[pos:start]
+        if content_fragment:
+            fragments.append((FragmentType.CONTENT, content_fragment))
+        needle = match.group(0)
+        try:
+            placeholder = placeholders[needle]
+            fragments.append((FragmentType.PLACEHOLDER, placeholder))
+        except KeyError:
+            fragments.append((FragmentType.CSRFTOKEN, None))
+        pos = end
+    content_fragment = content[end:]
+    if content_fragment:
+        fragments.append((FragmentType.CONTENT, content_fragment))
+    return fragments
+
+
+def render_content_fragments(fragments, placeholders, request):
+    csrf_token = get_token(request)
+    if csrf_token is None:
+        csrf_token = ''
+
+    content = []
+    for fragment_type, fragment_content in fragments:
+        if fragment_type == FragmentType.CONTENT:
+            content.append(fragment_content)
+        elif fragment_type == FragmentType.PLACEHOLDER:
+            try:
+                placeholder_content = str(placeholders[fragment_content]).encode()
+            except KeyError:
+                placeholder_content = b''
+            content.append(placeholder_content)
+        elif fragment_type == FragmentType.CSRFTOKEN:
+            content.append(csrf_token.encode())
+        else:
+            raise ValueError('Invalid fragment type: {}'.format(fragment_type))
+    return b''.join(content)
+
+
+def get_placeholder_token():
+    return base64.b32encode(os.urandom(35)).decode()

--- a/privacyscore/flexcache/templatetags/flexcache.py
+++ b/privacyscore/flexcache/templatetags/flexcache.py
@@ -1,0 +1,17 @@
+from .. import get_placeholder_token
+
+from django import template
+
+
+register = template.Library()
+
+@register.simple_tag(takes_context=True)
+def fc_placeholder(context, name):
+    if 'request' not in context:
+        return ''
+    request = context['request']
+    if not hasattr(request, 'flexcache_placeholders'):
+        request.flexcache_placeholders = {}
+    token = get_placeholder_token()
+    request.flexcache_placeholders[token] = name
+    return token

--- a/privacyscore/flexcache/tests.py
+++ b/privacyscore/flexcache/tests.py
@@ -1,0 +1,55 @@
+from django.test import TestCase, RequestFactory
+
+from . import FragmentType, get_placeholder_token, build_content_fragments, render_content_fragments
+
+
+class TestBuildContentFragments(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_build(self):
+        request = self.factory.get('/foo')
+        username_token = get_placeholder_token()
+        num_messages_token = get_placeholder_token()
+        request.flexcache_placeholders = {
+            username_token: 'username',
+            num_messages_token: 'num_messages'
+        }
+        content = 'Hello {}{} you have {} messages.'.format(username_token,
+                                                            username_token,
+                                                            num_messages_token)
+        fragments = build_content_fragments(content, request)
+        expected_fragments = [
+            (FragmentType.CONTENT, 'Hello '),
+            (FragmentType.PLACEHOLDER, 'username'),
+            (FragmentType.PLACEHOLDER, 'username'),
+            (FragmentType.CONTENT, ' you have '),
+            (FragmentType.PLACEHOLDER, 'num_messages'),
+            (FragmentType.CONTENT, ' messages.')
+        ]
+        self.assertEqual(fragments, expected_fragments)
+
+    def test_build_simple(self):
+        request = self.factory.get('/foo')
+        content = 'foobar'
+        fragments = build_content_fragments(content, request)
+        expected_fragments = [(FragmentType.CONTENT, 'foobar')]
+        self.assertEqual(fragments, expected_fragments)
+
+    def test_render(self):
+        request = self.factory.get('/foo')
+        username_token = get_placeholder_token()
+        num_messages_token = get_placeholder_token()
+        request.flexcache_placeholders = {
+            username_token: 'username',
+            num_messages_token: 'num_messages'
+        }
+        content_template = 'Hello {} you have {} messages.'.format(username_token,
+                                                                   num_messages_token)
+        fragments = build_content_fragments(content_template, request)
+        content = render_content_fragments(fragments, {
+            'username': 'foobar',
+            'num_messages': 42
+        }, request)
+        expected_content = 'Hello foobar you have 42 messages.'
+        self.assertEqual(content, expected_content)

--- a/privacyscore/frontend/views.py
+++ b/privacyscore/frontend/views.py
@@ -219,10 +219,10 @@ def view_scan_list(request: HttpRequest, scan_list_id: int, format: str = 'html'
 
     last_scan_pk = scan_list.last_scan.pk if scan_list.last_scan else 0
     cache_prefix = 'view_scan_list:{}:{}'.format(scan_list.pk, last_scan_pk)
-    return flexcache_view(view_scan_list_cachable, cache_prefix)(request, scan_list, format)
+    return flexcache_view(render_scan_list_cachable, cache_prefix)(request, scan_list, format)
 
 
-def view_scan_list_cachable(request: HttpRequest, scan_list, format: str = 'html'):
+def render_scan_list_cachable(request: HttpRequest, scan_list, format: str = 'html'):
     column_choices = [(None, _('- None -'))] + list(enumerate(x.name for x in scan_list.ordered_columns))
 
     class ConfigurationForm(forms.Form):
@@ -488,6 +488,7 @@ def site_screenshot(request: HttpRequest, site_id: int) -> HttpResponse:
 
 
 def view_site(request: HttpRequest, site_id: int) -> HttpResponse:
+    """View a site and its most recent scan result (if any)."""
     site = get_object_or_404(
         Site.objects.annotate_most_recent_scan_start() \
             .annotate_most_recent_scan_end_or_null() \
@@ -497,11 +498,11 @@ def view_site(request: HttpRequest, site_id: int) -> HttpResponse:
 
     last_scan_pk = site.last_scan.pk if site.last_scan else 0
     cache_key = 'view_site:{}:{}'.format(site.pk, last_scan_pk)
-    return flexcache_view(view_site_cachable, cache_key)(request, site)
+    return flexcache_view(render_site_cachable, cache_key)(request, site)
 
-def view_site_cachable(request: HttpRequest, site) -> TemplateResponse:
-    """View a site and its most recent scan result (if any)."""
 
+def render_site_cachable(request: HttpRequest, site) -> TemplateResponse:
+    """Render a site and its most recent scan result (if any), used by view_site"""
     num_scans = Scan.objects.filter(site_id=site.pk).count()
     scan_lists = ScanList.objects.filter(private=False, sites=site.pk)
 

--- a/privacyscore/frontend/views.py
+++ b/privacyscore/frontend/views.py
@@ -266,8 +266,6 @@ def render_scan_list_cachable(request: HttpRequest, scan_list, format: str = 'ht
         'right': ','.join(_move_element(category_order, category, 1))
     } for category in category_order]
 
-    #sites = cache.get('scan_list_{}:evaluated_sites'.format(scan_list.pk))
-    #if sites is None:
     sites = scan_list.sites.annotate_most_recent_scan_error_count() \
         .annotate_most_recent_scan_start().annotate_most_recent_scan_end_or_null() \
         .annotate_most_recent_scan_result().prefetch_column_values(scan_list) \
@@ -284,13 +282,7 @@ def render_scan_list_cachable(request: HttpRequest, scan_list, format: str = 'ht
         else:
             site.evaluated = UnrateableSiteEvaluation()
 
-    #cache.set(
-    #    'scan_list_{}:evaluated_sites'.format(scan_list.pk),
-    #    sites,
-    #    settings.CACHE_DEFAULT_TIMEOUT_SECONDS)
-
     sites = sorted(sites, key=lambda v: v.evaluated, reverse=True)
-
 
     # Sorting and grouping by attributes
     sort_by = None

--- a/privacyscore/frontend/views.py
+++ b/privacyscore/frontend/views.py
@@ -219,7 +219,9 @@ def view_scan_list(request: HttpRequest, scan_list_id: int, format: str = 'html'
 
     last_scan_pk = scan_list.last_scan.pk if scan_list.last_scan else 0
     cache_prefix = 'view_scan_list:{}:{}'.format(scan_list.pk, last_scan_pk)
-    return flexcache_view(render_scan_list_cachable, cache_prefix)(request, scan_list, format)
+    cached_view = flexcache_view(render_scan_list_cachable, cache_prefix,
+                                 timeout=settings.SITE_LIST_CACHE_TIMEOUT)
+    return cached_view(request, scan_list, format)
 
 
 def render_scan_list_cachable(request: HttpRequest, scan_list, format: str = 'html'):

--- a/privacyscore/frontend/views.py
+++ b/privacyscore/frontend/views.py
@@ -492,7 +492,8 @@ def view_site(request: HttpRequest, site_id: int) -> HttpResponse:
 
     last_scan_pk = site.last_scan.pk if site.last_scan else 0
     cache_key = 'view_site:{}:{}'.format(site.pk, last_scan_pk)
-    return flexcache_view(render_site_cachable, cache_key)(request, site)
+    cached_view = flexcache_view(render_site_cachable, cache_key, timeout=settings.SITE_CACHE_TIMEOUT)
+    return cached_view(request, site)
 
 
 def render_site_cachable(request: HttpRequest, site) -> TemplateResponse:

--- a/privacyscore/settings.py.example
+++ b/privacyscore/settings.py.example
@@ -104,7 +104,7 @@ CACHES = {
         }
     }
 }
-CACHE_DEFAULT_TIMEOUT_SECONDS = 1800
+SITE_LIST_CACHE_TIMEOUT = 3600 * 24 * 14
 
 
 # Password validation

--- a/privacyscore/settings.py.example
+++ b/privacyscore/settings.py.example
@@ -105,6 +105,7 @@ CACHES = {
     }
 }
 SITE_LIST_CACHE_TIMEOUT = 3600 * 24 * 14
+SITE_CACHE_TIMEOUT = 3600 * 24
 
 
 # Password validation


### PR DESCRIPTION
This adds a flexible module for caching whole views even with CSRF tokens and applies it to view_scan_list and view_site