### PR TITLE
Fix third party false positives trackers

### DIFF
--- a/privacyscore/test_suites/openwpm.py
+++ b/privacyscore/test_suites/openwpm.py
@@ -514,6 +514,11 @@ def detect_trackers(third_parties):
     i = 0
     
     for url in third_parties:
+        url = url.lower()
+        if url.startswith('https://'):
+            url = url[8:]
+        if url.startswith('http://'):
+            url = url[7:]
         if abr.should_block(url):
             ext = tldextract.extract(url)
             result.append("{}.{}".format(ext.domain, ext.suffix))

--- a/privacyscore/test_suites/openwpm.py
+++ b/privacyscore/test_suites/openwpm.py
@@ -514,11 +514,14 @@ def detect_trackers(third_parties):
     i = 0
     
     for url in third_parties:
+        # Remove protocol information, as this seems to cause false positives in AdblockParser.
+        # See PR #51 on Github for details
         url = url.lower()
         if url.startswith('https://'):
             url = url[8:]
         if url.startswith('http://'):
             url = url[7:]
+        # Now check if we should block it
         if abr.should_block(url):
             ext = tldextract.extract(url)
             result.append("{}.{}".format(ext.domain, ext.suffix))


### PR DESCRIPTION
For some reason, als URLs starting with http:// or https:// were declared trackers.  This commit strips the protocol from the URLs. We'll have to see if this was the only bug causing this. The root cause seems to lie with adblockparser, which we should replace with the Princeton code anyway.

See #48.